### PR TITLE
Wrong directory for modal cards imports. Fixed.

### DIFF
--- a/Front_end/src/Components/ReviewList/ReviewList.js
+++ b/Front_end/src/Components/ReviewList/ReviewList.js
@@ -1,9 +1,9 @@
 import React, { Component } from "react";
 import styled from "styled-components";
 import axios from "axios";
-import NewReviewModalCard from "../ReviewList/NewReviewModalCard";
-import EditReviewModalCard from "../ReviewList/EditReviewModalCard";
-import ViewReviewModalCard from "../ReviewList/ViewReviewModalCard";
+import NewReviewModalCard from "../CardModals/NewReviewModalCard";
+import EditReviewModalCard from "../CardModals/EditReviewModalCard";
+import ViewReviewModalCard from "../CardModals/ViewReviewModalCard";
 import {
   Breadcrumb,
   MenuItem,


### PR DESCRIPTION
# Description
Used wrong directory to import card modals. Should be fixed.

## Type of Change
 - [x] Bug fix (non-breaking change witch fixes an issue)

## Change status
 - [x] Complete, but not tested (may need new tests)
 
 # Checklist
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self review of my own code
 - [x] My changes generate no new warnings
 - [x] There are no merge conflicts
